### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "jurdns-groq-node"
+description = "This node utilizes the Groq.com API to enhance prompts. (Place API key and main system prompt in the groq_config.json)"
+version = "1.0.0"
+license = {file = "LICENSE"}
+dependencies = ["groq"]
+
+[project.urls]
+Repository = "https://github.com/jurdnisglobby/ComfyUI-Jurdns-Groq-Node"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-Jurdns-Groq-Node"
+Icon = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,6 @@ Repository = "https://github.com/jurdnisglobby/ComfyUI-Jurdns-Groq-Node"
 #  Used by Comfy Registry https://comfyregistry.org
 
 [tool.comfy]
-PublisherId = ""
+PublisherId = "jurdn"
 DisplayName = "ComfyUI-Jurdns-Groq-Node"
 Icon = ""


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. 

Eventually, the registry will be integrated as a backend for the UI-manager where all nodes will go through a security scan. Nodes that pass these checks will have a verification flag (✅) beside their name on the UI-manager. Feel free to read up more on the registry [here](https://docs.comfy.org/registry/overview#introduction)

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Otherwise, if you have any questions, please message me on discord at robinken or join our [server](https://discord.com/invite/comfyorg)!